### PR TITLE
Added missing PHP extensions: Soap and Mcrypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 RUN apt-get update -y && apt-get install -y ssh libpng-dev libmagickwand-dev libjpeg-dev libmemcached-dev zlib1g-dev libzip-dev git unzip subversion ca-certificates libicu-dev libxml2-dev libmcrypt-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/
 
 # PHP Extensions - PECL
-RUN pecl install imagick-3.4.4 memcached mcrypt-1.0.3 && docker-php-ext-enable imagick memcached mcrypt
+RUN pecl install imagick-3.4.4 memcached mcrypt-1.0.4 && docker-php-ext-enable imagick memcached mcrypt
 
 # PHP Extensions - docker-php-ext-install
 RUN docker-php-ext-install zip gd mysqli exif pdo pdo_mysql opcache intl soap

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,15 @@ RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 # Dependencies
-RUN apt-get update -y && apt-get install -y ssh libpng-dev libmagickwand-dev libjpeg-dev libmemcached-dev zlib1g-dev libzip-dev git unzip subversion ca-certificates libicu-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/
+RUN apt-get update -y && apt-get install -y ssh libpng-dev libmagickwand-dev libjpeg-dev libmemcached-dev zlib1g-dev libzip-dev git unzip subversion ca-certificates libicu-dev libxml2-dev libmcrypt-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/
 
 # PHP Extensions - PECL
-RUN pecl install imagick-3.4.4 memcached && docker-php-ext-enable imagick memcached
+RUN pecl install imagick-3.4.4 memcached mcrypt-1.0.3 && docker-php-ext-enable imagick memcached mcrypt
 
 # PHP Extensions - docker-php-ext-install
-RUN docker-php-ext-install zip gd mysqli exif pdo pdo_mysql opcache intl
+RUN docker-php-ext-install zip gd mysqli exif pdo pdo_mysql opcache intl soap
 
-# PGP Extensions - docker-php-ext-configure
+# PHP Extensions - docker-php-ext-configure
 RUN docker-php-ext-configure intl
 
 # PHP Tools


### PR DESCRIPTION
# Description

Added [Mycrypt](https://www.php.net/manual/en/book.mcrypt.php) and [Soap](https://www.php.net/manual/en/book.soap.php) PHP extensions on the Dockerfile.

## Type of changes

New feature (non-breaking change which adds functionality)

## Additions
- Added new PHP extension _[PECL]_ [**mcrypt-1.0.3**](https://pecl.php.net/package/mcrypt/1.0.3)
- Added new PHP extension [**Soap**](https://www.php.net/manual/en/book.soap.php)
- Added 2 new dependencies [**libxml2-dev**](https://packages.debian.org/stretch/libxml2-dev), [**libmcrypt-dev**](https://packages.debian.org/stretch/libmcrypt-dev)